### PR TITLE
add python lib imposm.parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ python
 ```bash
 sudo apt-get install build-essential python-dev python-pip protobuf-compiler libprotobuf-dev;
 [sudo] pip install imposm.parser;
+[sudo] pip install ujson;
 ```
 
 ### run test

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The tests involve decompressing a PBF extract of London stored on SSD and serial
 - `node-osmium` https://github.com/osmcode/node-osmium
 - `node-osmium-stream` https://github.com/geopipes/osmium-stream
 - `go-osmpbf` https://github.com/qedus/osmpbf
+- `py-imposm-parser` https://github.com/omniscale/imposm-parser
 
 ## results
 
@@ -40,21 +41,31 @@ Make sure you have the most current versions of the following installed:
 - nodejs
 - golang
 - mercurial (for the golang dep)
+- python
 
 for impartial PBF stats I use:
 - osmconvert (sudo apt-get install osmctools)
 
 ### dependencies
 
+node/golang
+
 ```bash
 go get github.com/qedus/osmpbf;
 npm install;
 ```
 
+python
+
+```bash
+sudo apt-get install build-essential python-dev python-pip protobuf-compiler libprotobuf-dev;
+[sudo] pip install imposm.parser;
+```
+
 ### run test
 
 ```bash
-bash run.sh
+bash run.sh;
 ```
 
 ### drive performance

--- a/imposm-parser.py
+++ b/imposm-parser.py
@@ -1,0 +1,46 @@
+
+import sys
+import json
+from imposm.parser import OSMParser
+from collections import OrderedDict # requires python 2.7+?
+
+# http://newbebweb.blogspot.co.uk/2012/02/python-head-ioerror-errno-32-broken.html
+from signal import signal, SIGPIPE, SIG_DFL
+signal(SIGPIPE,SIG_DFL)
+
+# simple class that handles the parsed OSM data.
+class JsonOutput(object):
+
+  def nodes(self, nodes):
+    for osmid, tags, coords in nodes:
+      output = OrderedDict([
+        ('type','node'), 
+        ('id', osmid), 
+        ('lat', coords[1]), 
+        ('lon', coords[0]),
+        ('tags', tags)
+      ])
+      sys.stdout.write( json.dumps(output, separators=(',',':')) + '\n' )
+
+  def ways(self, ways):
+    for osmid, tags, refs in ways:
+      output = OrderedDict([
+        ('type','way'), 
+        ('id', osmid), 
+        ('refs', refs), 
+        ('tags', tags)
+      ])
+      sys.stdout.write( json.dumps(output, separators=(',',':')) + '\n' )
+
+  def relations(self, relations):
+    return; # do nothing (yet)
+
+# instantiate counter and parser and start parsing
+jsonify = JsonOutput()
+p = OSMParser(
+  # concurrency=4, # defaults to the number of CPU and cores of the host system
+  nodes_callback=jsonify.nodes,
+  ways_callback=jsonify.ways,
+  relations_callback=jsonify.relations
+)
+p.parse(sys.argv[1])

--- a/imposm-parser.py
+++ b/imposm-parser.py
@@ -11,13 +11,24 @@ signal(SIGPIPE,SIG_DFL)
 # simple class that handles the parsed OSM data.
 class JsonOutput(object):
 
+  # coords are nodes without tags
+  def coords(self, coords):
+    for osmid, lon, lat in coords:
+      output = OrderedDict([
+        ('type','node'),
+        ('id', osmid),
+        ('lat', lat),
+        ('lon', lon)
+      ])
+      sys.stdout.write( json.dumps(output, separators=(',',':')) + '\n' )
+
   def nodes(self, nodes):
-    for osmid, tags, coords in nodes:
+    for osmid, tags, centroid in nodes:
       output = OrderedDict([
         ('type','node'), 
         ('id', osmid), 
-        ('lat', coords[1]), 
-        ('lon', coords[0]),
+        ('lat', centroid[1]),
+        ('lon', centroid[0]),
         ('tags', tags)
       ])
       sys.stdout.write( json.dumps(output, separators=(',',':')) + '\n' )
@@ -39,6 +50,7 @@ class JsonOutput(object):
 jsonify = JsonOutput()
 p = OSMParser(
   # concurrency=4, # defaults to the number of CPU and cores of the host system
+  coords_callback=jsonify.coords,
   nodes_callback=jsonify.nodes,
   ways_callback=jsonify.ways,
   relations_callback=jsonify.relations

--- a/imposm-parser.py
+++ b/imposm-parser.py
@@ -1,6 +1,6 @@
 
 import sys
-import json
+import ujson
 from imposm.parser import OSMParser
 from collections import OrderedDict # requires python 2.7+?
 
@@ -14,34 +14,53 @@ class JsonOutput(object):
   # coords are nodes without tags
   def coords(self, coords):
     for osmid, lon, lat in coords:
-      output = OrderedDict([
-        ('type','node'),
-        ('id', osmid),
-        ('lat', lat),
-        ('lon', lon)
-      ])
-      sys.stdout.write( json.dumps(output, separators=(',',':')) + '\n' )
+      # output = OrderedDict([
+      #   ('type','node'),
+      #   ('id', osmid),
+      #   ('lat', lat),
+      #   ('lon', lon)
+      # ])
+      output = {
+        'type': 'node',
+        'id': osmid,
+        'lat': lat,
+        'lon': lon
+      }
+      sys.stdout.write( ujson.dumps(output) + '\n' )
 
   def nodes(self, nodes):
     for osmid, tags, centroid in nodes:
-      output = OrderedDict([
-        ('type','node'), 
-        ('id', osmid), 
-        ('lat', centroid[1]),
-        ('lon', centroid[0]),
-        ('tags', tags)
-      ])
-      sys.stdout.write( json.dumps(output, separators=(',',':')) + '\n' )
+      # output = OrderedDict([
+      #   ('type','node'),
+      #   ('id', osmid),
+      #   ('lat', centroid[1]),
+      #   ('lon', centroid[0]),
+      #   ('tags', tags)
+      # ])
+      output = {
+        'type': 'node',
+        'id': osmid,
+        'lat': centroid[1],
+        'lon': centroid[0],
+        'tags': tags
+      }
+      sys.stdout.write( ujson.dumps(output) + '\n' )
 
   def ways(self, ways):
     for osmid, tags, refs in ways:
-      output = OrderedDict([
-        ('type','way'), 
-        ('id', osmid), 
-        ('refs', refs), 
-        ('tags', tags)
-      ])
-      sys.stdout.write( json.dumps(output, separators=(',',':')) + '\n' )
+      # output = OrderedDict([
+      #   ('type','way'),
+      #   ('id', osmid),
+      #   ('refs', refs),
+      #   ('tags', tags)
+      # ])
+      output = {
+        'type': 'way',
+        'id': osmid,
+        'refs': refs,
+        'tags': tags
+      }
+      sys.stdout.write( ujson.dumps(output) + '\n' )
 
   def relations(self, relations):
     return; # do nothing (yet)

--- a/run.sh
+++ b/run.sh
@@ -15,25 +15,28 @@ stats(){
   echo "shasum: (`shasum tmpfile`)";
 }
 
-echo '--- osm-pbf-parser ---';
-time node osm-pbf-parser $PBF_FILE >tmpfile;
-stats; rm tmpfile; echo;
+# echo '--- osm-pbf-parser ---';
+# time node osm-pbf-parser $PBF_FILE >tmpfile;
+# stats; rm tmpfile; echo;
 
-echo '--- osm-read ---';
-time node osm-read $PBF_FILE >tmpfile;
-cp tmpfile tmp1;
-stats; rm tmpfile; echo;
+# echo '--- osm-read ---';
+# time node osm-read $PBF_FILE >tmpfile;
+# cp tmpfile tmp1;
+# stats; rm tmpfile; echo;
 
-echo '--- node-osmium ---';
-time node node-osmium $PBF_FILE >tmpfile;
-cp tmpfile tmp2;
-stats; rm tmpfile; echo;
+# echo '--- node-osmium ---';
+# time node node-osmium $PBF_FILE >tmpfile;
+# cp tmpfile tmp2;
+# stats; rm tmpfile; echo;
 
-echo '--- node-osmium-stream ---';
-time node node-osmium-stream $PBF_FILE >tmpfile;
-stats; rm tmpfile; echo;
+# echo '--- node-osmium-stream ---';
+# time node node-osmium-stream $PBF_FILE >tmpfile;
+# stats; rm tmpfile; echo;
 
 echo '--- go-osmpbf ---';
 time go run osmpbf.go $PBF_FILE >tmpfile;
 stats; rm tmpfile; echo;
 
+echo '--- py-imposm-parser ---';
+time python imposm-parser.py $PBF_FILE >tmpfile;
+stats; rm tmpfile; echo;

--- a/run.sh
+++ b/run.sh
@@ -10,8 +10,8 @@ osmconvert --out-statistics $PBF_FILE; echo;
 
 stats(){
   echo "total lines: `cat tmpfile | wc -l`";
-  echo "total nodes: `cat tmpfile | grep node | wc -l`";
-  echo "total ways: `cat tmpfile | grep refs | wc -l`";
+  echo "total nodes: `cat tmpfile | grep '\"node\"' | wc -l`";
+  echo "total ways: `cat tmpfile | grep '\"way\"' | wc -l`";
   echo "shasum: (`shasum tmpfile`)";
 }
 


### PR DESCRIPTION
First stab at adding `imposm.parser` to benchmarks in response to https://github.com/pelias/pbf-parser-comparison/issues/1

I couldn't get [the script](https://github.com/pelias/pbf-parser-comparison/blob/py-imposm-parser/imposm-parser.py) to output exactly what I wanted (which is only one line for each `node OR coords`) so it's currently outputting 2 lines per `node`; one from the `coords_callback` and one for the `nodes_callback`.

``` bash
$ grep 564571123 tmpfile2
{"type":"node","id":564571123,"lat":-41.26042920000001,"lon":174.86484979999992}
{"type":"node","id":564571123,"lat":-41.26042920000001,"lon":174.86484979999992,"tags":{"tourism":"viewpoint"}}
```

I've never written any python before, so if someone can fix it, please do.
Maybe @olt can help out?

@naoliv here are some preliminary results so at least you can get an impression of relative speed.

``` bash
$ ./run.sh 

--- pbf stats ---

file: /mnt/london_england.osm.pbf

lon min: -1.1149997
lon max: 0.8949991
lat min: 50.9410000
lat max: 51.9839997
nodes: 9861732
ways: 1390940
relations: 29157
node id min: 19
node id max: 3257561964
way id min: 73
way id max: 319342625
relation id min: 58
relation id max: 4436318
keyval pairs max: 255
keyval pairs max object: relation 62149
noderefs max: 1760
noderefs max object: way 204596511
relrefs max: 1143
relrefs max object: relation 2793118

--- go-osmpbf ---

real    1m40.932s
user    1m20.594s
sys 0m20.242s
total lines: 11252672
total nodes: 9861732
total ways: 1390940
shasum: (ec01984a0286c3ebb2ccb930de527c55c716e3b5  tmpfile)

--- py-imposm-parser ---

real    6m17.258s
user    7m11.600s
sys 0m4.261s
total lines: 11858571
total nodes: 10467631
total ways: 1390940
shasum: (2e33c1389e9bd168f1adf2e13b832a31e9208978  tmpfile)
```

I think the way I'm viewing CPU usages is wrong, for all the libs I see 100% on one core and little work being done on other cores, even with `concurrency: 8`.

![cpu usage](http://peter.johnson.s3.amazonaws.com/cpu-usage.png)
